### PR TITLE
Replaces `uncaughtException` with `prepareStackTrace`

### DIFF
--- a/scripts/coffee/lib/PrettyError.coffee
+++ b/scripts/coffee/lib/PrettyError.coffee
@@ -54,13 +54,15 @@ module.exports = class PrettyError
 
 	start: (cb) ->
 
-		process.on 'uncaughtException', (exc) =>
+		oldPrepareStackTrace = Error.prepareStackTrace
 
-			@render exc, yes
+		# https://code.google.com/p/v8/wiki/JavaScriptStackTraceApi
 
-			process.exit 1
+		Error.prepareStackTrace = (exc, trace) =>
 
-			return
+			stack = oldPrepareStackTrace.apply null, arguments
+
+			@render {stack, message: exc.toString().replace /^.*: /, ''}, no
 
 		process.nextTick cb if cb?
 

--- a/scripts/coffee/test/PrettyError.coffee
+++ b/scripts/coffee/test/PrettyError.coffee
@@ -1,5 +1,9 @@
 require './_prepare'
 
+isFormatted = (exc) ->
+
+	exc.stack.indexOf('  \u001b[0m\u001b[97m\u001b[41m') is 0
+
 error = (what) ->
 
 	if typeof what is 'string'
@@ -99,3 +103,28 @@ it "should work", ->
 	e6 = error -> PrettyError.someNonExistingFuncion()
 
 	console.log p.render e6, no
+
+describe "start()"
+
+it "throws unformatted error when not started", ->
+
+	try
+
+		throw new Error "foo bar"
+
+	catch exc
+
+	expect(isFormatted exc).to.be.false
+
+it "throws formatted the error", ->
+
+	PrettyError.start()
+
+	try
+
+		throw new Error "foo bar"
+
+	catch exc
+
+	expect(isFormatted exc).to.be.true
+


### PR DESCRIPTION
`uncaughtException` doesn't work well with majority of test harnesses because they catch and display exceptions. This patch replaces `uncaughtException` console logging with a more "correct" way that better integrates into most stacks and leaves it up to the user to decide what to do with exceptions.

This is a direct port of functionality with a few additional tests.

Thoughts?
