### PR TITLE
Remove non-essential files from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.0.1",
   "description": "See nodejs errors with less clutter",
   "main": "./lib/PrettyError.js",
+  "files": [
+    "index.d.ts",
+    "lib"
+  ],
   "scripts": {
     "test": "mocha \"test/**/*.coffee\"",
     "test:watch": "mocha \"test/**/*.coffee\" --watch",


### PR DESCRIPTION
Whitelist files to avoid publishing `src`, `test`, `.npmignore` and `.travis.yml` to npm.

https://docs.npmjs.com/files/package.json#files
