### PR TITLE
Add stripBeforeColon config value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ declare module 'pretty-error' {
             | PrettyError.Callback
             | PrettyError.Callback[];
             aliases?: boolean | Object;
+            stripBeforeColon?: boolean;
         }
 
         type Callback = (traceLine: Object | any, lineNumber: number) => boolean;
@@ -54,6 +55,8 @@ declare module 'pretty-error' {
         removeAlias(stringOrRx: string): PrettyError;
         removeAllAliases(): PrettyError;
         appendStyle(toAppend: Object): PrettyError;
+        stripBeforeColon(): PrettyError;
+        dontStripBeforeColon(): PrettyError;
         render(
             e: PrettyError.ParsedError,
             logIt?: boolean,

--- a/src/PrettyError.coffee
+++ b/src/PrettyError.coffee
@@ -63,6 +63,7 @@ module.exports = class PrettyError
     instance?.stop()
 
   constructor: ->
+    @_stripBeforeColon = yes
     @_useColors = yes
     @_maxItems = 50
     @_packagesToSkip = []
@@ -86,7 +87,7 @@ module.exports = class PrettyError
     # https://code.google.com/p/v8/wiki/JavaScriptStackTraceApi
     Error.prepareStackTrace = (exc, trace) =>
       stack = prepeare.apply(null, arguments)
-      @render {stack, message: exc.toString().replace /^.*: /, ''}, no
+      @render {stack, message: if @_stripBeforeColon then exc.toString().replace /^.*: /, '' else exc }, no
 
     @
 
@@ -112,7 +113,7 @@ module.exports = class PrettyError
         @unskipAll()
       else
         @skip.apply @, c.skip
-
+        
     if c.maxItems?
       @setMaxItems c.maxItems
 
@@ -138,6 +139,12 @@ module.exports = class PrettyError
         @alias path, alias for path, alias of c.aliases
       else if c.aliases is no
         @removeAllAliases()
+
+    if c.stripBeforeColon?
+      if c.stripBeforeColon is yes
+        @stripBeforeColon()
+      else
+        @dontStripBeforeColon()
 
     @
 
@@ -228,6 +235,14 @@ module.exports = class PrettyError
     arrayUtils.pluckByCallback @_aliases, (pair) ->
       pair.stringOrRx is stringOrRx
 
+    @
+    
+  stripBeforeColon: () ->
+    @_stripBeforeColon = yes
+    @
+    
+  dontStripBeforeColon: () ->
+    @_stripBeforeColon = no
     @
 
   removeAllAliases: ->


### PR DESCRIPTION
Removing everything before the colon on the stack trace breaks some messages of the libraries I use; I'd like it to be optional. Hope this doesn't break anything.