### PR TITLE
Adds support for disabling extra newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ pe.filter(function(traceLine, lineNumber){
 pe.withoutColors(); // Errors will be rendered without coloring
 ```
 
+## Disabling extra newlines between stack frames
+```javascript
+var PrettyError = require('pretty-error');
+var pe = new PrettyError({ extraNewlines: false });
+```
+
 ## Integrating with frameworks
 
 PrettyError is very simple to set up, so it should be easy to use within other frameworks.

--- a/src/PrettyError.coffee
+++ b/src/PrettyError.coffee
@@ -5,7 +5,7 @@ nodePaths = require './nodePaths'
 RenderKid = require 'renderkid'
 merge = require 'lodash/merge'
 
-arrayUtils = 
+arrayUtils =
   pluckByCallback: (a, cb) ->
     return a if a.length < 1
     removed = 0
@@ -62,7 +62,7 @@ module.exports = class PrettyError
   @stop: ->
     instance?.stop()
 
-  constructor: ->
+  constructor: (opts = { extraNewlines: true })->
     @_useColors = yes
     @_maxItems = 50
     @_packagesToSkip = []
@@ -71,7 +71,9 @@ module.exports = class PrettyError
     @_filterCallbacks = []
     @_parsedErrorFilters = []
     @_aliases = []
-    @_renderer = new RenderKid
+
+    renderKidConfig = { layout: { extraNewlines: opts.extraNewlines } }
+    @_renderer = new RenderKid renderKidConfig
     @_style = self._getDefaultStyle()
     @_renderer.style @_style
 

--- a/test/PrettyError.coffee
+++ b/test/PrettyError.coffee
@@ -79,6 +79,21 @@ describe "PrettyError", ->
       e = error -> "a".should.equal "b"
       console.log p.render e, no
 
+    it "should omit newlines if opts.extraNewlines is false", ->
+      p = new PrettyError({ extraNewlines: false })
+      p.withoutColors()
+      p.skipPackage('mocha')
+
+      f1 = () -> throw new Error('test error')
+      f2 = () -> f1()
+      f3 = () -> f2()
+
+      try
+        f3()
+      catch exc
+        rendered = p.render exc, no
+        rendered.split(/\n/g).length.should.be.eql 12
+
   describe "start()", ->
     prepareStackTrace = null
 


### PR DESCRIPTION
Partially resolves #67. Depends on [AriaMinaei/RenderKid#30](https://github.com/AriaMinaei/RenderKid/pull/30).

Changes:

- Adds an `opts` parameter to the constructor, with a default value which results in no behavioral changes
- Allows setting `opts.extraNewlines` to false to remove extra newlines between stack frames in RenderKid